### PR TITLE
chore: restore mev-boost sidecar

### DIFF
--- a/main.star
+++ b/main.star
@@ -263,83 +263,83 @@ def run(plan, args={}):
         )
         mev_endpoints.append(helix_endpoint)
 
-    # spin up the mev boost contexts if some endpoints for relays have been passed
-    all_mevboost_contexts = []
-    if mev_endpoints:
-        for index, participant in enumerate(all_participants):
-            index_str = shared_utils.zfill_custom(
-                index + 1, len(str(len(all_participants)))
-            )
-            if args_with_right_defaults.participants[index].validator_count != 0:
-                if mev_params.bolt_boost_image == None:
-                    mev_boost_launcher = mev_boost.new_mev_boost_launcher(
-                        MEV_BOOST_SHOULD_CHECK_RELAY,
-                        mev_endpoints,
-                    )
-                    mev_boost_service_name = "{0}-{1}-{2}-{3}".format(
-                        input_parser.MEV_BOOST_SERVICE_NAME_PREFIX,
-                        index_str,
-                        participant.cl_type,
-                        participant.el_type,
-                    )
-                    mev_boost_context = mev_boost.launch(
-                        plan,
-                        mev_boost_launcher,
-                        mev_boost_service_name,
-                        network_params.network_id,
-                        mev_params.mev_boost_image,
-                        mev_params.mev_boost_args,
-                        global_node_selectors,
-                        network_params,
-                    )
-                    all_mevboost_contexts.append(mev_boost_context)
+        # spin up the mev boost contexts if some endpoints for relays have been passed
+        all_mevboost_contexts = []
+        if mev_endpoints:
+            for index, participant in enumerate(all_participants):
+                index_str = shared_utils.zfill_custom(
+                    index + 1, len(str(len(all_participants)))
+                )
+                if args_with_right_defaults.participants[index].validator_count != 0:
+                    if mev_params.bolt_boost_image == None:
+                        mev_boost_launcher = mev_boost.new_mev_boost_launcher(
+                            MEV_BOOST_SHOULD_CHECK_RELAY,
+                            mev_endpoints,
+                        )
+                        mev_boost_service_name = "{0}-{1}-{2}-{3}".format(
+                            input_parser.MEV_BOOST_SERVICE_NAME_PREFIX,
+                            index_str,
+                            participant.cl_type,
+                            participant.el_type,
+                        )
+                        mev_boost_context = mev_boost.launch(
+                            plan,
+                            mev_boost_launcher,
+                            mev_boost_service_name,
+                            network_params.network_id,
+                            mev_params.mev_boost_image,
+                            mev_params.mev_boost_args,
+                            global_node_selectors,
+                            network_params,
+                        )
+                        all_mevboost_contexts.append(mev_boost_context)
 
-                else:
-                    bolt_boost_service_name = "{0}-{1}-{2}-{3}".format(
-                        input_parser.BOLT_BOOST_SERVICE_NAME_PREFIX,
-                        index_str,
-                        participant.cl_type,
-                        participant.el_type,
-                    )
-                    relays_config = [{
-                        "id": "helix_relay",
-                        "url": helix_endpoint,
-                    }]
-                    bolt_sidecar_config = {
-                        "constraints_api_url": "{0}:{1}".format(
-                            bolt_boost.BOLT_BOOST_BASE_URL, bolt_boost.BOLT_BOOST_PORT
-                        ),
-                        "beacon_api_url": all_cl_contexts[0].beacon_http_url,
-                        "execution_api_url": "http://{0}:{1}".format(
-                            all_el_contexts[0].ip_addr,
-                            all_el_contexts[0].rpc_port_num,
-                        ),
-                        "engine_api_url": "http://{0}:{1}".format(
-                            all_el_contexts[0].ip_addr,
-                            all_el_contexts[0].engine_rpc_port_num
-                        ),
-                        "jwt_hex": raw_jwt_secret,
-                        "metrics_port": bolt_sidecar.BOLT_SIDECAR_METRICS_PORT,
-                    }
-                    bolt_boost_context = bolt_boost.launch(
-                        plan,
-                        mev_params.bolt_boost_image,
-                        bolt_boost_service_name,
-                        relays_config,
-                        bolt_sidecar_config,
-                        network_params,
-                        final_genesis_timestamp,
-                        global_node_selectors,
-                    )
-                    all_mevboost_contexts.append(bolt_boost_context)
-                    # add bolt-sidecar
-                    bolt_sidecar_context = bolt_sidecar.launch_bolt_sidecar(
-                        plan,
-                        mev_params.bolt_sidecar_image,
-                        bolt_sidecar_config,
-                        network_params,
-                        global_node_selectors,
-                    )
+                    else:
+                        bolt_boost_service_name = "{0}-{1}-{2}-{3}".format(
+                            input_parser.BOLT_BOOST_SERVICE_NAME_PREFIX,
+                            index_str,
+                            participant.cl_type,
+                            participant.el_type,
+                        )
+                        relays_config = [{
+                            "id": "helix_relay",
+                            "url": helix_endpoint,
+                        }]
+                        bolt_sidecar_config = {
+                            "constraints_api_url": "{0}:{1}".format(
+                                bolt_boost.BOLT_BOOST_BASE_URL, bolt_boost.BOLT_BOOST_PORT
+                            ),
+                            "beacon_api_url": all_cl_contexts[0].beacon_http_url,
+                            "execution_api_url": "http://{0}:{1}".format(
+                                all_el_contexts[0].ip_addr,
+                                all_el_contexts[0].rpc_port_num,
+                            ),
+                            "engine_api_url": "http://{0}:{1}".format(
+                                all_el_contexts[0].ip_addr,
+                                all_el_contexts[0].engine_rpc_port_num
+                            ),
+                            "jwt_hex": raw_jwt_secret,
+                            "metrics_port": bolt_sidecar.BOLT_SIDECAR_METRICS_PORT,
+                        }
+                        bolt_boost_context = bolt_boost.launch(
+                            plan,
+                            mev_params.bolt_boost_image,
+                            bolt_boost_service_name,
+                            relays_config,
+                            bolt_sidecar_config,
+                            network_params,
+                            final_genesis_timestamp,
+                            global_node_selectors,
+                        )
+                        all_mevboost_contexts.append(bolt_boost_context)
+                        # add bolt-sidecar
+                        bolt_sidecar_context = bolt_sidecar.launch_bolt_sidecar(
+                            plan,
+                            mev_params.bolt_sidecar_image,
+                            bolt_sidecar_config,
+                            network_params,
+                            global_node_selectors,
+                        )
 
     if len(args_with_right_defaults.additional_services) == 0:
         output = struct(

--- a/src/mev/bolt_boost/bolt_boost_launcher.star
+++ b/src/mev/bolt_boost/bolt_boost_launcher.star
@@ -2,18 +2,15 @@ shared_utils = import_module("../../shared_utils/shared_utils.star")
 mev_boost_context_module = import_module("../mev_boost/mev_boost_context.star")
 static_files = import_module("../../static_files/static_files.star")
 constants = import_module("../../package_io/constants.star")
-
-FLASHBOTS_MEV_BOOST_PROTOCOL = "TCP"
+input_parser = import_module("../../package_io/input_parser.star")
 
 SERVICE_NAME = "bolt-boost"
-BOLT_BOOST_BASE_URL = "http://{0}".format(SERVICE_NAME)
-BOLT_BOOST_PORT = 9062
 BOLT_BOOST_CONFIG_FILENAME="cb-bolt-config.toml"
 BOLT_BOOST_CONFIG_MOUNT_DIRPATH_ON_SERVICE="/config"
 
 USED_PORTS = {
     "api": shared_utils.new_port_spec(
-        BOLT_BOOST_PORT, "TCP", wait="5s"
+        input_parser.FLASHBOTS_MEV_BOOST_PORT, "TCP", wait="5s"
     )
 }
 
@@ -123,7 +120,7 @@ def new_bolt_boost_config_template_data(
             "genesis_fork_version": constants.GENESIS_FORK_VERSION,
         },
         "image": image,
-        "port": BOLT_BOOST_PORT,
+        "port": input_parser.FLASHBOTS_MEV_BOOST_PORT,
         "relays_config": [
             {
                 "id": relay_config["id"],
@@ -137,6 +134,6 @@ def new_bolt_boost_config_template_data(
             "engine_api_url": bolt_sidecar_config["engine_api_url"],
             "jwt_hex": bolt_sidecar_config["jwt_hex"],
             "metrics_port": bolt_sidecar_config["metrics_port"],
-            "builder_proxy_port": BOLT_BOOST_PORT,
+            "builder_proxy_port": input_parser.FLASHBOTS_MEV_BOOST_PORT,
         }
     }

--- a/src/mev/bolt_sidecar/bolt_sidecar_launcher.star
+++ b/src/mev/bolt_sidecar/bolt_sidecar_launcher.star
@@ -1,11 +1,8 @@
 redis_module = import_module("github.com/kurtosis-tech/redis-package/main.star")
 postgres_module = import_module("github.com/kurtosis-tech/postgres-package/main.star")
 constants = import_module("../../package_io/constants.star")
-bolt_boost = import_module("../bolt_boost/bolt_boost_launcher.star")
-mev_boost_context_util = import_module("../mev_boost/mev_boost_context.star")
+input_parser = import_module("../../package_io/input_parser.star")
 
-SERVICE_NAME = "bolt-sidecar"
-BOLT_SIDECAR_BASE_URL = "http://{}".format(SERVICE_NAME)
 BOLT_SIDECAR_COMMITMENTS_API_PORT = 9061
 BOLT_SIDECAR_METRICS_PORT = 9063
 
@@ -27,7 +24,7 @@ def launch_bolt_sidecar(
     }
 
     api = plan.add_service(
-        name=SERVICE_NAME,
+        name=sidecar_config["service_name"],
         config=ServiceConfig(
             image=image,
             cmd=[
@@ -39,7 +36,7 @@ def launch_bolt_sidecar(
                 "--constraints-url",
                 sidecar_config["constraints_api_url"],
                 "--constraints-proxy-port",
-                str(bolt_boost.BOLT_BOOST_PORT),
+                str(input_parser.FLASHBOTS_MEV_BOOST_PORT),
                 "--beacon-api-url",
                 sidecar_config["beacon_api_url"],
                 "--execution-api-url",
@@ -67,7 +64,7 @@ def launch_bolt_sidecar(
                     number=BOLT_SIDECAR_COMMITMENTS_API_PORT, transport_protocol="TCP"
                 ),
                 "bolt-boost": PortSpec(
-                    number=bolt_boost.BOLT_BOOST_PORT, transport_protocol="TCP"
+                    number=input_parser.FLASHBOTS_MEV_BOOST_PORT, transport_protocol="TCP"
                 ),
                 "metrics": PortSpec(
                     number=BOLT_SIDECAR_METRICS_PORT, transport_protocol="TCP"


### PR DESCRIPTION
This PR allows better configurability of this package by spinning up Bolt-Boost only if the image is provided, otherwise it will fall back to MEV-Boost.

Also closes #14 