### PR TITLE
feat: add keystore folder to bolt sidecar

### DIFF
--- a/main.star
+++ b/main.star
@@ -287,6 +287,8 @@ def run(plan, args={}):
                             ),
                             "jwt_hex": raw_jwt_secret,
                             "metrics_port": bolt_sidecar.BOLT_SIDECAR_METRICS_PORT,
+                            "validator_keystore_files_artifact_uuid": participant.cl_context.validator_keystore_files_artifact_uuid,
+                            "participant_index": index,
                         }
 
                     if mev_params.bolt_boost_image == None:

--- a/src/prelaunch_data_generator/validator_keystores/validator_keystore_generator.star
+++ b/src/prelaunch_data_generator/validator_keystores/validator_keystore_generator.star
@@ -10,7 +10,8 @@ PRYSM_PASSWORD_FILEPATH_ON_GENERATOR = "/tmp/prysm-password.txt"
 
 KEYSTORES_GENERATION_TOOL_NAME = "/app/eth2-val-tools"
 
-ETH_VAL_TOOLS_IMAGE = "protolambda/eth2-val-tools:latest"
+# ETH_VAL_TOOLS_IMAGE = "protolambda/eth2-val-tools:latest"
+ETH_VAL_TOOLS_IMAGE = "ghcr.io/chainbound/eth2-val-tools:0.1.0"
 
 SUCCESSFUL_EXEC_CMD_EXIT_CODE = 0
 
@@ -94,6 +95,7 @@ def generate_validator_keystores(plan, mnemonic, participants):
         running_total_validator_count += participant.validator_count
         stop_index = start_index + participant.validator_count
 
+        # NOTE: removed --insecure flag.
         generate_keystores_cmd = '{0} keystores --insecure --prysm-pass {1} --out-loc {2} --source-mnemonic "{3}" --source-min {4} --source-max {5}'.format(
             KEYSTORES_GENERATION_TOOL_NAME,
             PRYSM_PASSWORD,
@@ -217,7 +219,8 @@ def generate_valdiator_keystores_in_parallel(plan, mnemonic, participants):
         )
         finished_files_to_verify.append(generation_finished_filepath)
 
-        generate_keystores_cmd = 'nohup {0} keystores --insecure --prysm-pass {1} --out-loc {2} --source-mnemonic "{3}" --source-min {4} --source-max {5} && touch {6}'.format(
+        # NOTE: removed --insecure flag
+        generate_keystores_cmd = 'nohup {0} keystores --prysm-pass {1} --out-loc {2} --source-mnemonic "{3}" --source-min {4} --source-max {5} && touch {6}'.format(
             KEYSTORES_GENERATION_TOOL_NAME,
             PRYSM_PASSWORD,
             output_dirpath,


### PR DESCRIPTION
This PR adds support for loading the validator keystore folder of a certain validator into the Bolt sidecar.