### PR TITLE
fix: sidecar ports

### DIFF
--- a/src/mev/bolt_sidecar/bolt_sidecar_launcher.star
+++ b/src/mev/bolt_sidecar/bolt_sidecar_launcher.star
@@ -45,7 +45,7 @@ def launch_bolt_sidecar(
                 "--constraints-api-url",
                 sidecar_config["constraints_api_url"],
                 "--constraints-proxy-port",
-                str(input_parser.FLASHBOTS_MEV_BOOST_PORT),
+                str(input_parser.BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT),
                 "--validator-indexes",
                 "0..64",
                 "--engine-jwt-hex",
@@ -76,8 +76,8 @@ def launch_bolt_sidecar(
                 "api": PortSpec(
                     number=BOLT_SIDECAR_COMMITMENTS_API_PORT, transport_protocol="TCP"
                 ),
-                "bolt-boost": PortSpec(
-                    number=input_parser.FLASHBOTS_MEV_BOOST_PORT, transport_protocol="TCP"
+                "bolt-sidecar": PortSpec(
+                    number=input_parser.BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT, transport_protocol="TCP"
                 ),
                 "metrics": PortSpec(
                     number=BOLT_SIDECAR_METRICS_PORT, transport_protocol="TCP"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -42,6 +42,7 @@ HIGH_DENEB_VALUE_FORK_VERKLE = 2000000000
 
 # MEV Params
 FLASHBOTS_MEV_BOOST_PORT = 18550
+BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT = 18551
 MEV_BOOST_SERVICE_NAME_PREFIX = "mev-boost"
 BOLT_BOOST_SERVICE_NAME_PREFIX = "bolt-boost"
 BOLT_SIDECAR_SERVICE_NAME_PREFIX = "bolt-sidecar"
@@ -152,8 +153,8 @@ def input_parser(plan, input_args):
         else:
             result = enrich_mev_extra_params(
                 result,
-                MEV_BOOST_SERVICE_NAME_PREFIX,
-                FLASHBOTS_MEV_BOOST_PORT,
+                BOLT_SIDECAR_SERVICE_NAME_PREFIX,
+                BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT,
                 result.get("mev_type"),
             )
 


### PR DESCRIPTION
MEV-Boost and the Bolt sidecar constraints proxy server were mapped on the same port which has started causing an issue. I don't know how it worked before lmao