### PR TITLE
chore!(helix): update config

### DIFF
--- a/static_files/helix-relay-config/config.yaml.tmpl
+++ b/static_files/helix-relay-config/config.yaml.tmpl
@@ -4,6 +4,8 @@ postgres:
   db_name: {{ .PostgresConfig.db_name }}
   user: {{ .PostgresConfig.user }}
   password: {{ .PostgresConfig.password }}
+  region: 0
+  region_name: "bolt"
 
 redis:
   url: {{ .RedisConfig.url }}
@@ -16,8 +18,21 @@ beacon_clients:
     - url: "{{ $bcConfig.url }}"
   {{- end }}
 
+builders:
+  # Reference: https://github.com/chainbound/bolt-builder/blob/main/cmd/utils/flags.go#L691-L691
+  - pub_key: "aa1488eae4b06a1fff840a2b6db167afc520758dc2c8af0dfb57037954df3431b747e2f900fe8805f05d635e9a29717b"
+    builder_info:
+      collateral: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+      is_optimistic: false
+      builder_id: "Bolt Builder"
+
+
 network_config:
   !Custom # this is a custom enum type and requies a '!'
     dir_path: {{ .NetworkConfig.dir_path }}
     genesis_validator_root: {{ .NetworkConfig.genesis_validator_root }}
     genesis_time: {{ .NetworkConfig.genesis_time }}
+
+# If empty, all routes are enabled
+router_config:
+  enabled_routes: []


### PR DESCRIPTION
Adds fields that are now required in Helix in its `develop` branch.

NOTE: this is indeed a breaking change, because it implies using the [constraints-api-v0](https://github.com/chainbound/helix/tree/constraints-api-v0) branch instead of the `bolt` branch of Helix for building images.