### PR TITLE
feat(helix): allow to extend config from kurtosis config file

### DIFF
--- a/main.star
+++ b/main.star
@@ -577,6 +577,7 @@ def run(plan, args={}):
         all_participants=all_participants,
         final_genesis_timestamp=final_genesis_timestamp,
         genesis_validators_root=genesis_validators_root,
+        mev_params=mev_params,
     )
 
     return output

--- a/src/mev/mev_relay/helix_launcher.star
+++ b/src/mev/mev_relay/helix_launcher.star
@@ -163,7 +163,7 @@ def launch_helix_relay(
         ),
     )
 
-    plan.print("Launched Helix relay with configuration: {0}".format(helix_config_template_data))
+    plan.print(json.indent(json.encode(helix_config_template_data)))
 
     return "http://{0}@{1}:{2}".format(
         DUMMY_PUB_KEY, helix.ip_address, HELIX_RELAY_ENDPOINT_PORT

--- a/src/mev/mev_relay/helix_launcher.star
+++ b/src/mev/mev_relay/helix_launcher.star
@@ -112,6 +112,7 @@ def launch_helix_relay(
         network_config_dir_path_on_service,
         validator_root,
         genesis_timestamp,
+        mev_params.helix_relay_config_extension,
     )
 
     helix_config_template_and_data = shared_utils.new_template_and_data(
@@ -162,6 +163,8 @@ def launch_helix_relay(
         ),
     )
 
+    plan.print("Launched Helix relay with configuration: {0}".format(helix_config_template_data))
+
     return "http://{0}@{1}:{2}".format(
         DUMMY_PUB_KEY, helix.ip_address, HELIX_RELAY_ENDPOINT_PORT
     )
@@ -178,27 +181,34 @@ def new_config_template_data(
     network_config_dir_path,
     genesis_validator_root,
     genesis_time,
+    config_extension,
 ):
-    return {
-        "PostgresConfig": {
+    config_hashmap = {
+        "postgres": {
             "hostname": postgres_hostname,
             "port": postgres_port,
             "db_name": postgres_db_name,
             "user": postgres_user,
             "password": postgres_password,
         },
-        "RedisConfig": {
+        "redis": {
             "url": redis_url,
         },
-        "BlockSimulatorConfig": {
+        "simulator": {
             "url": blocksim_url,
         },
-        "BeaconClientsConfig": [
+        "beacon_clients": [
             {"url": uri} for uri in beacon_uris
         ],
-        "NetworkConfig": {
+        "network_config": {
             "dir_path": network_config_dir_path,
             "genesis_validator_root": genesis_validator_root,
             "genesis_time": genesis_time,
         },
     }
+
+    if config_extension != None:
+        for key, value in config_extension.items():
+            config_hashmap[key] = value
+
+    return config_hashmap

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -262,6 +262,7 @@ def input_parser(plan, input_args):
             mev_relay_website_extra_args=result["mev_params"][
                 "mev_relay_website_extra_args"
             ],
+            helix_relay_config_extension=result["mev_params"]["helix_relay_config_extension"],
             mev_builder_extra_args=result["mev_params"]["mev_builder_extra_args"],
             mev_flood_image=result["mev_params"]["mev_flood_image"],
             mev_flood_extra_args=result["mev_params"]["mev_flood_extra_args"],
@@ -731,7 +732,8 @@ def get_default_mev_params():
         "mev_relay_api_extra_args": [],
         "mev_relay_housekeeper_extra_args": [],
         "mev_relay_website_extra_args": [],
-        "mev_builder_extra_args": [],
+        "helix_relay_config_extension": None,
+        "mev_builder_extra_args": None,
         "mev_flood_image": "flashbots/mev-flood",
         "mev_flood_extra_args": [],
         "mev_flood_seconds_per_bundle": 15,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -143,10 +143,10 @@ def input_parser(plan, input_args):
         result = enrich_disable_peer_scoring(result)
 
     if result.get("mev_type") in ("mock", "full"):
-        if result.get("mev_params")["bolt_boost_image"] != None:
+        if result.get("mev_params")["bolt_sidecar_image"] == None:
             result = enrich_mev_extra_params(
                 result,
-                BOLT_BOOST_SERVICE_NAME_PREFIX,
+                MEV_BOOST_SERVICE_NAME_PREFIX,
                 FLASHBOTS_MEV_BOOST_PORT,
                 result.get("mev_type"),
             )

--- a/static_files/helix-relay-config/config.yaml.tmpl
+++ b/static_files/helix-relay-config/config.yaml.tmpl
@@ -1,20 +1,20 @@
 postgres:
-  hostname: {{ .PostgresConfig.hostname }}
-  port: {{ .PostgresConfig.port }}
-  db_name: {{ .PostgresConfig.db_name }}
-  user: {{ .PostgresConfig.user }}
-  password: {{ .PostgresConfig.password }}
+  hostname: {{ .postgres.hostname }}
+  port: {{ .postgres.port }}
+  db_name: {{ .postgres.db_name }}
+  user: {{ .postgres.user }}
+  password: {{ .postgres.password }}
   region: 0
   region_name: "bolt"
 
 redis:
-  url: {{ .RedisConfig.url }}
+  url: {{ .redis.url }}
 
 simulator:
-  url: {{ .BlockSimulatorConfig.url }}
+  url: {{ .simulator.url }}
 
 beacon_clients:
-  {{ range $bcConfig := .BeaconClientsConfig }}
+  {{ range $bcConfig := .beacon_clients }}
     - url: "{{ $bcConfig.url }}"
   {{- end }}
 
@@ -26,12 +26,17 @@ builders:
       is_optimistic: false
       builder_id: "Bolt Builder"
 
+{{- if .constraints_api_config }}
+constraints_api_config:
+  check_constraints_signature: {{ .constraints_api_config.check_constraints_signature }}
+  max_block_value_to_verify_wei: {{ .constraints_api_config.max_block_value_to_verify_wei }}
+{{- end }}
 
 network_config:
   !Custom # this is a custom enum type and requies a '!'
-    dir_path: {{ .NetworkConfig.dir_path }}
-    genesis_validator_root: {{ .NetworkConfig.genesis_validator_root }}
-    genesis_time: {{ .NetworkConfig.genesis_time }}
+    dir_path: {{ .network_config.dir_path }}
+    genesis_validator_root: {{ .network_config.genesis_validator_root }}
+    genesis_time: {{ .network_config.genesis_time }}
 
 # If empty, all routes are enabled
 router_config:


### PR DESCRIPTION
This PR allows using the `kurtosis_config.yaml` file as follows:
```yaml
mev_params:
    # ...
    helix_relay_config_extension:
    	constraints_api_config:
      		check_constraints_signature: false
      		max_block_value_to_verify_wei: "0x00000000000000000000000000000000000000000000000000000000deadbeef"
     # ...
```