### PR TITLE
chore(bolt): update grafana dash

### DIFF
--- a/src/grafana/grafana_launcher.star
+++ b/src/grafana/grafana_launcher.star
@@ -3,7 +3,7 @@ static_files = import_module("../static_files/static_files.star")
 
 SERVICE_NAME = "grafana"
 
-IMAGE_NAME = "grafana/grafana-enterprise:9.5.12"
+IMAGE_NAME = "grafana/grafana-enterprise:11.1.0"
 
 HTTP_PORT_ID = "http"
 HTTP_PORT_NUMBER_UINT16 = 3000

--- a/static_files/grafana-config/dashboards/bolt-sidecar.json
+++ b/static_files/grafana-config/dashboards/bolt-sidecar.json
@@ -18,41 +18,254 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
+  "id": 1,
   "links": [],
   "liveNow": false,
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Sidecar Metrics",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "bolt-prometheus"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 0,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bolt-prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "bolt_sidecar_latest_head",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Latest slot",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bolt-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 5,
+        "y": 1
+      },
+      "id": 16,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto",
+        "text": {}
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bolt-prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(time() - container_start_time_seconds{name=~\"bolt-(sidecar|mev-boost|boost).*\"})/3600",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bolt-prometheus"
+      },
+      "description": "Tracks the reasons for rejecting an inclusion request.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 10,
+      "options": {
+        "displayLabels": ["name"],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bolt-prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "bolt_sidecar_validation_errors",
+          "legendFormat": "{{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Invalid transaction reasons",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bolt-prometheus"
+      },
+      "description": "The number of preconfirmed transactions categorized by transaction type.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic",
+            "seriesBy": "last"
+          },
+          "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -83,7 +296,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 9
       },
       "id": 9,
       "options": {
@@ -102,49 +315,53 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "bolt-prometheus"
           },
           "editorMode": "builder",
           "expr": "bolt_sidecar_transactions_preconfirmed",
-          "legendFormat": "__auto",
+          "legendFormat": "{{type}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Transactions Preconfirmed",
+      "title": "Preconfirmed transactions",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "bolt-prometheus"
       },
+      "description": "The revenue from all of the preconfirmed transactions. This is \"gross\" revenue because it just adds all of the priority fees in those transactions, which may be partly split with the builder in case of a PBS block.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "semi-dark-blue",
+            "mode": "fixed"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "ETH",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -175,9 +392,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 9
       },
-      "id": 10,
+      "id": 17,
       "options": {
         "legend": {
           "calcs": [],
@@ -194,49 +411,58 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "bolt-prometheus"
           },
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "bolt_sidecar_validation_errors",
-          "legendFormat": "__auto",
+          "expr": "bolt_sidecar_gross_tip_revenue / 1000000000000000000",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{job}}",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "useBackend": false
         }
       ],
-      "title": "Invalid Transactions Reasons",
+      "title": "Gross tip revenue",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "bolt-prometheus"
       },
+      "description": "The number of inclusion requests that were accepted (i.e. committed to).",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "green",
+            "mode": "fixed"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "stepAfter",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -263,9 +489,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 17
       },
-      "id": 2,
+      "id": 5,
       "options": {
         "legend": {
           "calcs": [],
@@ -282,49 +508,53 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "bolt-prometheus"
           },
           "editorMode": "builder",
-          "expr": "bolt_sidecar_remote_blocks_proposed",
-          "legendFormat": "__auto",
+          "expr": "bolt_sidecar_inclusion_commitments_accepted",
+          "legendFormat": "requests",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Remote Blocks Proposed",
+      "title": "Inclusion requests accepted",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "bolt-prometheus"
       },
+      "description": "The number of inclusion requests received.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "light-orange",
+            "mode": "fixed"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "stepAfter",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -355,7 +585,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 17
       },
       "id": 4,
       "options": {
@@ -374,49 +604,148 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "bolt-prometheus"
           },
           "editorMode": "builder",
           "expr": "bolt_sidecar_inclusion_commitments_received",
-          "legendFormat": "__auto",
+          "legendFormat": "requests",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Inclusion Commitments Received",
+      "title": "Inclusion requests",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "bolt-prometheus"
       },
+      "description": "The number of PBS blocks proposed (as opposed to local fallback blocks).",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "dark-blue",
+            "mode": "fixed"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bolt-prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "bolt_sidecar_remote_blocks_proposed",
+          "legendFormat": "blocks",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "PBS blocks proposed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bolt-prometheus"
+      },
+      "description": "The number of fallback blocks proposed. Fallback blocks are only proposed in case of a PBS failure. If this number is high, something might be wrong.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "shades"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 9,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
             "lineInterpolation": "stepAfter",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -441,38 +770,13 @@
             ]
           }
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "{__name__=\"bolt_sidecar_local_blocks_proposed\", instance=\"172.16.0.25:9063\", job=\"bolt-sidecar\"}"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 16
+        "x": 12,
+        "y": 25
       },
       "id": 8,
       "options": {
@@ -492,25 +796,42 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "bolt-prometheus"
           },
+          "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
           "expr": "bolt_sidecar_local_blocks_proposed",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
           "instant": false,
           "interval": "",
-          "legendFormat": "__auto",
+          "legendFormat": "blocks",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "useBackend": false
         }
       ],
-      "title": "Local Blocks Proposed",
+      "title": "Fallback blocks proposed",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 12,
+      "panels": [],
+      "title": "System Metrics",
+      "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "bolt-prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -518,26 +839,28 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "stepAfter",
+            "insertNulls": false,
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -554,51 +877,59 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
-          }
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 34
       },
-      "id": 5,
+      "id": 13,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "right",
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
+          "mode": "multi",
           "sort": "none"
         }
       },
+      "pluginVersion": "7.4.5",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "bolt-prometheus"
           },
-          "editorMode": "builder",
-          "expr": "bolt_sidecar_inclusion_commitments_accepted",
-          "legendFormat": "__auto",
+          "editorMode": "code",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{name=~\"bolt-sidecar.*|bolt-mev-boost.*|bolt-boost.*\"}[5m])) by (name) *100",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Inclusion Commitments Accepted",
+      "title": "CPU usage",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "bolt-prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -606,6 +937,106 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "bolt-prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(container_memory_rss{name=~\"bolt-sidecar.*|bolt-boost.*|bolt-mev-boost.*\"}) by (name)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "bolt-prometheus"
+      },
+      "description": "Total HTTP requests grouped by HTTP method & response code.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -619,13 +1050,14 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -656,7 +1088,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 49
       },
       "id": 6,
       "options": {
@@ -675,38 +1107,44 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "bolt-prometheus"
           },
           "editorMode": "builder",
           "expr": "bolt_sidecar_http_requests_total",
-          "legendFormat": "__auto",
+          "legendFormat": "{{method}} / {{status}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Total HTTP Requests",
+      "title": "Total HTTP requests",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "bolt-prometheus"
       },
+      "description": "Request processing durations per HTTP method.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
           "custom": {
-            "fillOpacity": 80,
+            "fillOpacity": 30,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "lineWidth": 1
+            "lineWidth": 0,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
           },
+          "decimals": 0,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -720,7 +1158,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
@@ -728,11 +1167,12 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 49
       },
       "id": 7,
       "options": {
         "bucketOffset": 0,
+        "combine": false,
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -744,81 +1184,25 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "bolt-prometheus"
           },
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "bolt_sidecar_http_requests_duration_seconds",
-          "legendFormat": "__auto",
+          "expr": "sum by(method) (bolt_sidecar_http_requests_duration_seconds)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "legendFormat": "{{method}}",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "useBackend": false
         }
       ],
-      "title": "HTTP Requests Durations in ms",
+      "title": "HTTP request durations",
       "type": "histogram"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 0,
-        "y": 32
-      },
-      "id": 3,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.12",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "builder",
-          "expr": "bolt_sidecar_latest_head",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Latest Head Slot",
-      "type": "stat"
     }
   ],
   "refresh": "",
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": []
@@ -829,8 +1213,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Bolt Sidecar",
-  "uid": "e5960f6d-a1ed-4538-9c7c-3ecba4d4b4b1",
-  "version": 3,
+  "title": "bolt-prometheus",
+  "uid": "bolt-prometheus",
+  "version": 24,
   "weekStart": ""
 }

--- a/static_files/grafana-config/dashboards/bolt-sidecar.json
+++ b/static_files/grafana-config/dashboards/bolt-sidecar.json
@@ -1135,8 +1135,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "prometheus",
-  "uid": "prometheus",
+  "title": "bolt sidecar",
+  "uid": "bolt-sidecar",
   "version": 24,
   "weekStart": ""
 }

--- a/static_files/grafana-config/dashboards/bolt-sidecar.json
+++ b/static_files/grafana-config/dashboards/bolt-sidecar.json
@@ -36,10 +36,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -83,10 +80,7 @@
       "pluginVersion": "11.1.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "editorMode": "builder",
           "expr": "bolt_sidecar_latest_head",
           "legendFormat": "__auto",
@@ -98,10 +92,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -149,10 +140,7 @@
       "pluginVersion": "11.1.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "editorMode": "code",
           "exemplar": false,
           "expr": "(time() - container_start_time_seconds{name=~\"bolt-(sidecar|mev-boost|boost).*\"})/3600",
@@ -168,10 +156,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "description": "Tracks the reasons for rejecting an inclusion request.",
       "fieldConfig": {
         "defaults": {
@@ -216,10 +201,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "editorMode": "builder",
           "exemplar": false,
           "expr": "bolt_sidecar_validation_errors",
@@ -232,10 +214,7 @@
       "type": "piechart"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "description": "The number of preconfirmed transactions categorized by transaction type.",
       "fieldConfig": {
         "defaults": {
@@ -313,10 +292,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "editorMode": "builder",
           "expr": "bolt_sidecar_transactions_preconfirmed",
           "legendFormat": "{{type}}",
@@ -328,10 +304,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "description": "The revenue from all of the preconfirmed transactions. This is \"gross\" revenue because it just adds all of the priority fees in those transactions, which may be partly split with the builder in case of a PBS block.",
       "fieldConfig": {
         "defaults": {
@@ -409,10 +382,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "bolt_sidecar_gross_tip_revenue / 1000000000000000000",
@@ -429,10 +399,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "description": "The number of inclusion requests that were accepted (i.e. committed to).",
       "fieldConfig": {
         "defaults": {
@@ -506,10 +473,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "editorMode": "builder",
           "expr": "bolt_sidecar_inclusion_commitments_accepted",
           "legendFormat": "requests",
@@ -521,10 +485,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "description": "The number of inclusion requests received.",
       "fieldConfig": {
         "defaults": {
@@ -602,10 +563,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "editorMode": "builder",
           "expr": "bolt_sidecar_inclusion_commitments_received",
           "legendFormat": "requests",
@@ -617,10 +575,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "description": "The number of PBS blocks proposed (as opposed to local fallback blocks).",
       "fieldConfig": {
         "defaults": {
@@ -697,10 +652,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "editorMode": "builder",
           "expr": "bolt_sidecar_remote_blocks_proposed",
           "legendFormat": "blocks",
@@ -712,10 +664,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "description": "The number of fallback blocks proposed. Fallback blocks are only proposed in case of a PBS failure. If this number is high, something might be wrong.",
       "fieldConfig": {
         "defaults": {
@@ -794,10 +743,7 @@
       "pluginVersion": "9.5.12",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
@@ -829,10 +775,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -910,10 +853,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "editorMode": "code",
           "expr": "sum(rate(container_cpu_usage_seconds_total{name=~\"bolt-sidecar.*|bolt-mev-boost.*|bolt-boost.*\"}[5m])) by (name) *100",
           "hide": false,
@@ -927,10 +867,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1008,10 +945,7 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "editorMode": "code",
           "expr": "sum(container_memory_rss{name=~\"bolt-sidecar.*|bolt-boost.*|bolt-mev-boost.*\"}) by (name)",
           "hide": false,
@@ -1025,10 +959,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "description": "Total HTTP requests grouped by HTTP method & response code.",
       "fieldConfig": {
         "defaults": {
@@ -1105,10 +1036,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "editorMode": "builder",
           "expr": "bolt_sidecar_http_requests_total",
           "legendFormat": "{{method}} / {{status}}",
@@ -1120,10 +1048,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "bolt-prometheus"
-      },
+      "datasource": {},
       "description": "Request processing durations per HTTP method.",
       "fieldConfig": {
         "defaults": {
@@ -1182,10 +1107,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "bolt-prometheus"
-          },
+          "datasource": {},
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "sum by(method) (bolt_sidecar_http_requests_duration_seconds)",
@@ -1213,8 +1135,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "bolt-prometheus",
-  "uid": "bolt-prometheus",
+  "title": "prometheus",
+  "uid": "prometheus",
   "version": 24,
   "weekStart": ""
 }


### PR DESCRIPTION
Updates the grafana dashboard according to our latest Holesky setup.

Note: the datasource is the default Prometheus server and it's set as `{}` in the `bolt-sidecar.json` dashboard file. When updating this dashboard, we should remember to set this to an empty object again.

Note: cadvisor stats not working because it is not running on the devnet. For now it's fine.

<img width="1713" alt="Screenshot 2024-11-26 at 10 49 36" src="https://github.com/user-attachments/assets/da5ecace-8641-4673-be05-81b40bd04c6a">
