### PR TITLE
feat: firewall delegation

### DIFF
--- a/main.star
+++ b/main.star
@@ -356,7 +356,7 @@ def run(plan, args={}):
                         bolt_sidecar_config["service_name"] = service_name
                         bolt_sidecar_context = bolt_sidecar.launch_bolt_sidecar(
                             plan,
-                            mev_params.bolt_sidecar_image,
+                            mev_params,
                             bolt_sidecar_config,
                             network_params,
                             global_node_selectors,

--- a/src/mev/bolt_sidecar/bolt_sidecar_launcher.star
+++ b/src/mev/bolt_sidecar/bolt_sidecar_launcher.star
@@ -16,7 +16,7 @@ BOLT_SIDECAR_MAX_MEMORY = 1024
 
 def launch_bolt_sidecar(
     plan,
-    image,
+    mev_params,
     sidecar_config,
     network_params,
     node_selectors,
@@ -29,60 +29,73 @@ def launch_bolt_sidecar(
     full_keystore_path = "{0}{1}/keys".format(BOLT_SIDECAR_KEYS_DIRMOUNT_PATH_ON_SERVICE, node_keystore_path)
     full_keystore_secrets_path = "{0}{1}/secrets".format(BOLT_SIDECAR_KEYS_DIRMOUNT_PATH_ON_SERVICE, node_keystore_path)
 
+    cmd = [
+        "--execution-api-url",
+        sidecar_config["execution_api_url"],
+        "--beacon-api-url",
+        sidecar_config["beacon_api_url"],
+        "--engine-api-url",
+        sidecar_config["engine_api_url"],
+        "--constraints-api-url",
+        sidecar_config["constraints_api_url"],
+        "--constraints-proxy-port",
+        str(input_parser.BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT),
+        "--engine-jwt-hex",
+        sidecar_config["jwt_hex"],
+        "--fee-recipient",
+        "0x0000000000000000000000000000000000000000",
+        "--builder-private-key", # Random private key for testing
+        "0x20c815cb2d37561479c7b6cae9737356b144760d00f1387bff17df4a3712c262",
+        "--operator-private-key", # Random private key for testing
+        "0x18d1c5302e734fd6fbfaa51828d42c4c6d3cbe020c42bab7dd15a2799cf00b82",
+        "--commitment-deadline",
+        str(100),
+        "--chain",
+        network_params.network,
+        "--slot-time",
+        str(network_params.seconds_per_slot),
+        # "--keystore-password",
+        # validator_keystore_generator.PRYSM_PASSWORD,
+        "--keystore-secrets-path",
+        full_keystore_secrets_path,
+        "--keystore-path",
+        full_keystore_path,
+        "--metrics-port",
+        str(BOLT_SIDECAR_METRICS_PORT),
+    ]
+
+    ports={
+        "bolt-sidecar": PortSpec(
+            number=input_parser.BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT, transport_protocol="TCP"
+        ),
+        "metrics": PortSpec(
+            number=BOLT_SIDECAR_METRICS_PORT, transport_protocol="TCP"
+        ),
+    }
+
+    extra_params = mev_params.bolt_sidecar_extra_params
+
+    if extra_params != None:
+        if "firewall_rpcs" in extra_params:
+            firewall_rpcs = extra_params["firewall_rpcs"]
+            cmd.append("--firewall-rpcs")
+            cmd.append(firewall_rpcs)
+        else:
+            cmd.append("--port")
+            cmd.append(str(BOLT_SIDECAR_COMMITMENTS_API_PORT))
+            ports["api"] = PortSpec(
+                number=BOLT_SIDECAR_COMMITMENTS_API_PORT, transport_protocol="TCP"
+            )
+
+
+
     api = plan.add_service(
         name=sidecar_config["service_name"],
         config=ServiceConfig(
-            image=image,
-            cmd=[
-                # "--port",
-                # str(BOLT_SIDECAR_COMMITMENTS_API_PORT),
-                "--firewall-rpcs",
-                "ws://host.docker.internal:8015/api/v1/firewall_stream",
-                "--execution-api-url",
-                sidecar_config["execution_api_url"],
-                "--beacon-api-url",
-                sidecar_config["beacon_api_url"],
-                "--engine-api-url",
-                sidecar_config["engine_api_url"],
-                "--constraints-api-url",
-                sidecar_config["constraints_api_url"],
-                "--constraints-proxy-port",
-                str(input_parser.BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT),
-                "--engine-jwt-hex",
-                sidecar_config["jwt_hex"],
-                "--fee-recipient",
-                "0x0000000000000000000000000000000000000000",
-                "--builder-private-key", # Random private key for testing
-                "0x20c815cb2d37561479c7b6cae9737356b144760d00f1387bff17df4a3712c262",
-                "--operator-private-key", # Random private key for testing
-                "0x18d1c5302e734fd6fbfaa51828d42c4c6d3cbe020c42bab7dd15a2799cf00b82",
-                "--commitment-deadline",
-                str(100),
-                "--chain",
-                network_params.network,
-                "--slot-time",
-                str(network_params.seconds_per_slot),
-                # "--keystore-password",
-                # validator_keystore_generator.PRYSM_PASSWORD,
-                "--keystore-secrets-path",
-                full_keystore_secrets_path,
-                "--keystore-path",
-                full_keystore_path,
-                "--metrics-port",
-                str(BOLT_SIDECAR_METRICS_PORT),
-            ],
+            image=mev_params.bolt_sidecar_image,
+            cmd=cmd,
             # + mev_params.mev_relay_api_extra_args,
-            ports={
-                # "api": PortSpec(
-                #     number=BOLT_SIDECAR_COMMITMENTS_API_PORT, transport_protocol="TCP"
-                # ),
-                "bolt-sidecar": PortSpec(
-                    number=input_parser.BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT, transport_protocol="TCP"
-                ),
-                "metrics": PortSpec(
-                    number=BOLT_SIDECAR_METRICS_PORT, transport_protocol="TCP"
-                ),
-            },
+            ports=ports,
             files={
                 BOLT_SIDECAR_KEYS_DIRMOUNT_PATH_ON_SERVICE: sidecar_config["validator_keystore_files_artifact_uuid"],
             },

--- a/src/mev/bolt_sidecar/bolt_sidecar_launcher.star
+++ b/src/mev/bolt_sidecar/bolt_sidecar_launcher.star
@@ -34,8 +34,10 @@ def launch_bolt_sidecar(
         config=ServiceConfig(
             image=image,
             cmd=[
-                "--port",
-                str(BOLT_SIDECAR_COMMITMENTS_API_PORT),
+                # "--port",
+                # str(BOLT_SIDECAR_COMMITMENTS_API_PORT),
+                "--firewall-rpcs",
+                "ws://host.docker.internal:8015/api/v1/firewall_stream",
                 "--execution-api-url",
                 sidecar_config["execution_api_url"],
                 "--beacon-api-url",
@@ -52,7 +54,7 @@ def launch_bolt_sidecar(
                 "0x0000000000000000000000000000000000000000",
                 "--builder-private-key", # Random private key for testing
                 "0x20c815cb2d37561479c7b6cae9737356b144760d00f1387bff17df4a3712c262",
-                "--commitment-private-key", # Random private key for testing
+                "--operator-private-key", # Random private key for testing
                 "0x18d1c5302e734fd6fbfaa51828d42c4c6d3cbe020c42bab7dd15a2799cf00b82",
                 "--commitment-deadline",
                 str(100),
@@ -71,9 +73,9 @@ def launch_bolt_sidecar(
             ],
             # + mev_params.mev_relay_api_extra_args,
             ports={
-                "api": PortSpec(
-                    number=BOLT_SIDECAR_COMMITMENTS_API_PORT, transport_protocol="TCP"
-                ),
+                # "api": PortSpec(
+                #     number=BOLT_SIDECAR_COMMITMENTS_API_PORT, transport_protocol="TCP"
+                # ),
                 "bolt-sidecar": PortSpec(
                     number=input_parser.BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT, transport_protocol="TCP"
                 ),

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -254,6 +254,7 @@ def input_parser(plan, input_args):
             mev_builder_cl_image=result["mev_params"]["mev_builder_cl_image"],
             mev_boost_image=result["mev_params"]["mev_boost_image"],
             bolt_sidecar_image=result["mev_params"]["bolt_sidecar_image"],
+            bolt_sidecar_extra_params=result["mev_params"]["bolt_sidecar_extra_params"],
             mev_boost_args=result["mev_params"]["mev_boost_args"],
             mev_relay_api_extra_args=result["mev_params"]["mev_relay_api_extra_args"],
             mev_relay_housekeeper_extra_args=result["mev_params"][
@@ -724,6 +725,8 @@ def default_participant():
 def get_default_mev_params():
     return {
         "bolt_boost_image": None,
+        "bolt_sidecar_image": None,
+        "bolt_sidecar_extra_params": {},
         "mev_relay_image": MEV_BOOST_RELAY_DEFAULT_IMAGE,
         "mev_builder_image": "flashbots/builder:latest",
         "mev_builder_cl_image": "sigp/lighthouse:latest",


### PR DESCRIPTION
This PR introduces support for firewall delegation on the sidecar configurable using the `mev_params.bolt_sidecar_extra_params` field of the `kurtosis_config.yaml` file.